### PR TITLE
Make reference to nimbella install symbolic

### DIFF
--- a/core/ruby2.6ActionLoop/Dockerfile
+++ b/core/ruby2.6ActionLoop/Dockerfile
@@ -48,7 +48,8 @@ RUN \
     && mkdir -p /proxy/bin /proxy/lib /proxy/action
 
 # install nim
-RUN curl https://apigcp.nimbella.io/downloads/nim/nim-install-linux.sh | bash
+ARG NIM_INSTALL_SCRIPT=https://apigcp.nimbella.io/downloads/nim/nim-install-linux.sh
+RUN curl ${NIM_INSTALL_SCRIPT} | bash
 
 WORKDIR /proxy
 COPY --from=builder_source /bin/proxy /bin/proxy_source


### PR DESCRIPTION
This provides flexibility in building the runtime with alternative versions of nim.